### PR TITLE
Use aware timezone internally in timestamped formatting

### DIFF
--- a/jaraco/logging.py
+++ b/jaraco/logging.py
@@ -1,7 +1,6 @@
 import os
 import logging
 import time
-import datetime
 import string
 import http.client
 
@@ -133,7 +132,7 @@ class TimestampFileHandler(logging.StreamHandler):
         if self._period_seconds:
             t -= t % self._period_seconds
         # convert it to a datetime object for formatting
-        dt = datetime.datetime.utcfromtimestamp(t)
+        dt = tempora.utc.fromtimestamp(t)
         # append the datestring to the filename
         # workaround for datetime.strftime not handling '' properly
         appended_date = (

--- a/newsfragments/3.feature.rst
+++ b/newsfragments/3.feature.rst
@@ -1,0 +1,1 @@
+Replaced deprecated datetime.utcfromtimestamp.


### PR DESCRIPTION
Avoids using `datetime.utcfromtimestamp`, deprecated since Python 3.12.